### PR TITLE
[BUG] Fix release circular dependency issue (#20)

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -47,18 +47,26 @@ jobs:
         # Find the latest compatible Rust release
         LATEST_RUST=$(gh release list --repo ${{ github.repository }} --limit 10 | grep -E "^rust-v" | head -1 | cut -f1)
         if [ -z "$LATEST_RUST" ]; then
-          echo "ERROR: No Rust release found. Please create a Rust release first."
+          echo "WARNING: No Rust release found. Building locally for testing."
           echo "Required ABI version: $REQUIRED_ABI"
-          exit 1
+
+          # Install cargo-zigbuild for portable builds
+          cargo install cargo-zigbuild
+
+          # Build the library locally
+          cargo zigbuild --release
+
+          # Set the library path to the locally built one
+          echo "TOKENIZERS_LIB_PATH=$(pwd)/target/release/libtokenizers.so" >> $GITHUB_ENV
+        else
+          echo "Using Rust release: $LATEST_RUST"
+          echo "Required ABI version: $REQUIRED_ABI"
+
+          gh release download $LATEST_RUST --pattern "libtokenizers-x86_64-unknown-linux-gnu.tar.gz"
+          mkdir -p test-lib
+          tar -xzf libtokenizers-x86_64-unknown-linux-gnu.tar.gz -C test-lib
+          echo "TOKENIZERS_LIB_PATH=$(pwd)/test-lib/libtokenizers.so" >> $GITHUB_ENV
         fi
-
-        echo "Using Rust release: $LATEST_RUST"
-        echo "Required ABI version: $REQUIRED_ABI"
-
-        gh release download $LATEST_RUST --pattern "libtokenizers-x86_64-unknown-linux-gnu.tar.gz"
-        mkdir -p test-lib
-        tar -xzf libtokenizers-x86_64-unknown-linux-gnu.tar.gz -C test-lib
-        echo "TOKENIZERS_LIB_PATH=$(pwd)/test-lib/libtokenizers.so" >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
@@ -78,18 +86,23 @@ jobs:
         # Find the latest compatible Rust release
         LATEST_RUST=$(gh release list --repo ${{ github.repository }} --limit 10 | grep -E "^rust-v" | head -1 | cut -f1)
         if [ -z "$LATEST_RUST" ]; then
-          echo "ERROR: No Rust release found. Please create a Rust release first."
+          echo "WARNING: No Rust release found. Building locally for testing."
           echo "Required ABI version: $REQUIRED_ABI"
-          exit 1
+
+          # Build the library locally
+          cargo build --release
+
+          # Set the library path to the locally built one
+          echo "TOKENIZERS_LIB_PATH=$(pwd)/target/release/libtokenizers.dylib" >> $GITHUB_ENV
+        else
+          echo "Using Rust release: $LATEST_RUST"
+          echo "Required ABI version: $REQUIRED_ABI"
+
+          gh release download $LATEST_RUST --pattern "libtokenizers-${ARCH}-apple-darwin.tar.gz"
+          mkdir -p test-lib
+          tar -xzf libtokenizers-${ARCH}-apple-darwin.tar.gz -C test-lib
+          echo "TOKENIZERS_LIB_PATH=$(pwd)/test-lib/libtokenizers.dylib" >> $GITHUB_ENV
         fi
-
-        echo "Using Rust release: $LATEST_RUST"
-        echo "Required ABI version: $REQUIRED_ABI"
-
-        gh release download $LATEST_RUST --pattern "libtokenizers-${ARCH}-apple-darwin.tar.gz"
-        mkdir -p test-lib
-        tar -xzf libtokenizers-${ARCH}-apple-darwin.tar.gz -C test-lib
-        echo "TOKENIZERS_LIB_PATH=$(pwd)/test-lib/libtokenizers.dylib" >> $GITHUB_ENV
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
@@ -102,18 +115,24 @@ jobs:
 
         $latestRust = gh release list --repo ${{ github.repository }} --limit 10 | Select-String -Pattern "^rust-v" | Select-Object -First 1
         if (-not $latestRust) {
-          Write-Error "No Rust release found. Please create a Rust release first."
+          Write-Host "WARNING: No Rust release found. Building locally for testing."
           Write-Host "Required ABI version: $requiredABI"
-          exit 1
-        }
-        $releaseTag = ($latestRust -split "`t")[0]
-        Write-Host "Using Rust release: $releaseTag"
-        Write-Host "Required ABI version: $requiredABI"
 
-        gh release download $releaseTag --pattern "libtokenizers-x86_64-pc-windows-msvc.tar.gz"
-        New-Item -ItemType Directory -Force -Path test-lib
-        tar -xzf libtokenizers-x86_64-pc-windows-msvc.tar.gz -C test-lib
-        "TOKENIZERS_LIB_PATH=$(Get-Location)\test-lib\tokenizers.dll" | Out-File -FilePath $env:GITHUB_ENV -Append
+          # Build the library locally
+          cargo build --release
+
+          # Set the library path to the locally built one
+          "TOKENIZERS_LIB_PATH=$(Get-Location)\target\release\tokenizers.dll" | Out-File -FilePath $env:GITHUB_ENV -Append
+        } else {
+          $releaseTag = ($latestRust -split "`t")[0]
+          Write-Host "Using Rust release: $releaseTag"
+          Write-Host "Required ABI version: $requiredABI"
+
+          gh release download $releaseTag --pattern "libtokenizers-x86_64-pc-windows-msvc.tar.gz"
+          New-Item -ItemType Directory -Force -Path test-lib
+          tar -xzf libtokenizers-x86_64-pc-windows-msvc.tar.gz -C test-lib
+          "TOKENIZERS_LIB_PATH=$(Get-Location)\test-lib\tokenizers.dll" | Out-File -FilePath $env:GITHUB_ENV -Append
+        }
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
@@ -147,7 +166,11 @@ jobs:
       id: rust-version
       run: |
         LATEST_RUST=$(gh release list --repo ${{ github.repository }} --limit 10 | grep -E "^rust-v" | head -1 | cut -f1)
-        echo "rust_version=$LATEST_RUST" >> $GITHUB_OUTPUT
+        if [ -z "$LATEST_RUST" ]; then
+          echo "rust_version=built-locally" >> $GITHUB_OUTPUT
+        else
+          echo "rust_version=$LATEST_RUST" >> $GITHUB_OUTPUT
+        fi
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,15 @@ The project uses separate release cycles for Rust and Go:
 - **Go releases**: Tagged with `vX.Y.Z` (e.g., `v0.1.0`)
 
 ### Creating Releases
-1. **Rust Library Release**:
+
+**Important**: For the first release or when no Rust releases exist, the Go release workflow will automatically build the Rust library locally as a fallback. However, it's recommended to create Rust releases first for better artifact management.
+
+1. **Rust Library Release** (recommended to do first):
    ```bash
    git tag rust-v0.1.0
    git push origin rust-v0.1.0
    ```
-   This triggers the `rust-release.yml` workflow which builds and releases library artifacts.
+   This triggers the `rust-release.yml` workflow which builds and releases library artifacts for all supported platforms.
 
 2. **Go Module Release**:
    ```bash
@@ -27,7 +30,8 @@ The project uses separate release cycles for Rust and Go:
    git push origin v0.1.0
    ```
    This triggers the `go-release.yml` workflow which creates a Go module release.
-   Note: Ensure a compatible Rust library release exists first.
+   - If Rust releases exist: Downloads and tests against the latest `rust-v*` release
+   - If no Rust releases exist: Builds the Rust library locally for testing (fallback)
 
 ### CI Workflows
 - **rust-ci.yml**: Runs on Rust code changes (src/**, Cargo.toml)
@@ -35,6 +39,13 @@ The project uses separate release cycles for Rust and Go:
 - **ci.yml**: Main integration tests running on all changes
 - **rust-release.yml**: Builds and releases Rust library artifacts
 - **go-release.yml**: Creates Go module releases
+
+### Troubleshooting Release Issues
+
+**Issue: First release or no Rust artifacts available**
+- The Go release workflow will automatically build the Rust library locally if no `rust-v*` releases are found
+- This prevents the circular dependency issue where Go releases need Rust artifacts that don't exist yet
+- Solution: Either create a Rust release first, or let the workflow build locally
 
 ## Build Commands
 


### PR DESCRIPTION
## Summary
- Resolves the circular dependency issue where Go releases fail when no Rust artifacts are available
- Allows the release process to work correctly even for first-time releases

## Problem
As described in issue #20, the Go release workflow would fail when trying to download Rust library artifacts that don't exist yet, creating a circular dependency.

## Solution
Modified the `go-release.yml` workflow to:
- Detect when no `rust-v*` releases are available
- Fall back to building the Rust library locally for testing
- This matches the pattern already used in `go-ci.yml`

## Changes
1. **go-release.yml**: Added fallback logic to build Rust library locally when no releases exist
2. **CLAUDE.md**: Updated documentation to clarify the release process and troubleshooting

## Test plan
- [x] Validated YAML syntax with `yq`
- [x] Reviewed that fallback logic matches existing pattern in go-ci.yml
- [ ] When merged, the next Go release will work even without Rust releases

## Fixes
Fixes #20