### PR TITLE
[PERF] Reuse HTTP client for HuggingFace downloads

### DIFF
--- a/huggingface.go
+++ b/huggingface.go
@@ -54,9 +54,12 @@ func initHFHTTPClient() {
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			MaxIdleConnsPerHost:   10,
+			ForceAttemptHTTP2:   true,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			// IdleConnTimeout: 90s is suitable for long-running processes that may
+			// have periods of inactivity between downloads. For short scripts that
+			// exit quickly, connections will be closed automatically on program exit.
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,

--- a/huggingface.go
+++ b/huggingface.go
@@ -1,14 +1,17 @@
 package tokenizers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,6 +27,10 @@ const (
 var (
 	HFHubBaseURL   = "https://huggingface.co" // Variable to allow testing with mock server
 	libraryVersion = "0.1.0"                  // Default version, will be set from library if available
+
+	// Shared HTTP client for HuggingFace downloads with connection pooling
+	hfHTTPClient *http.Client
+	hfClientOnce sync.Once
 )
 
 // GetLibraryVersion returns the current library version used in User-Agent
@@ -36,6 +43,37 @@ func SetLibraryVersion(version string) {
 	if version != "" {
 		libraryVersion = version
 	}
+}
+
+// initHFHTTPClient initializes the shared HTTP client with connection pooling
+func initHFHTTPClient() {
+	hfClientOnce.Do(func() {
+		transport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			MaxIdleConnsPerHost:   10,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+
+		hfHTTPClient = &http.Client{
+			Transport: transport,
+			// Default timeout - will be overridden per-request using context
+			Timeout: 0,
+		}
+	})
+}
+
+// getHFHTTPClient returns the shared HTTP client for HuggingFace downloads
+func getHFHTTPClient() *http.Client {
+	initHFHTTPClient()
+	return hfHTTPClient
 }
 
 // HFConfig holds HuggingFace-specific configuration
@@ -223,11 +261,11 @@ func downloadTokenizerFromHF(modelID string, config *HFConfig) ([]byte, error) {
 
 // downloadWithRetry performs a single download attempt
 func downloadWithRetry(url string, config *HFConfig) ([]byte, error) {
-	client := &http.Client{
-		Timeout: config.Timeout,
-	}
+	// Create a context with timeout for this specific request
+	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}
@@ -238,6 +276,8 @@ func downloadWithRetry(url string, config *HFConfig) ([]byte, error) {
 		req.Header.Set("Authorization", "Bearer "+config.Token)
 	}
 
+	// Use the shared HTTP client with connection pooling
+	client := getHFHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")


### PR DESCRIPTION
## Summary
- Implements HTTP client reuse with connection pooling for HuggingFace downloads
- Improves performance and reduces latency for multiple download operations
- Fixes #50

## Changes
- Added shared HTTP client at package level with `sync.Once` initialization
- Configured Transport with appropriate connection pooling settings
- Modified `downloadWithRetry()` to use the shared client with per-request context timeout
- Added comprehensive tests for concurrent downloads and client initialization

## Technical Details
### Connection Pooling Configuration
- **MaxIdleConns**: 100 - Maximum number of idle connections across all hosts
- **MaxIdleConnsPerHost**: 10 - Maximum idle connections per host
- **IdleConnTimeout**: 90s - How long idle connections are kept alive
- **ForceAttemptHTTP2**: true - Prefer HTTP/2 when available

### Implementation
- Uses `sync.Once` to ensure thread-safe initialization of the shared client
- Per-request timeout using `context.WithTimeout()` instead of client-level timeout
- Maintains backward compatibility with existing HFConfig timeout settings

## Benefits
✅ Better connection reuse and pooling
✅ Reduced latency for subsequent requests  
✅ Lower resource usage (fewer TCP connections)
✅ Better performance for batch downloads
✅ Thread-safe implementation

## Test Plan
- [x] Added test for concurrent downloads (`TestConcurrentDownloads`)
- [x] Added test for client initialization (`TestHTTPClientInitialization`)
- [x] All existing tests pass
- [x] Linting passes