### PR TITLE
[ENH] Add sentinel error for cache-not-found condition

### DIFF
--- a/huggingface.go
+++ b/huggingface.go
@@ -50,6 +50,9 @@ var (
 	// Shared HTTP client for HuggingFace downloads with connection pooling
 	hfHTTPClient *http.Client
 	hfClientOnce sync.Once
+
+	// ErrCacheNotFound is returned when a requested cache file does not exist
+	ErrCacheNotFound = errors.New("cache file not found")
 )
 
 // GetLibraryVersion returns the current library version used in User-Agent
@@ -883,7 +886,7 @@ func loadFromCacheWithValidation(path string, ttl time.Duration) ([]byte, error)
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, errors.New("cache file not found")
+			return nil, ErrCacheNotFound
 		}
 		return nil, errors.Wrap(err, "failed to stat cache file")
 	}

--- a/huggingface_cache_test.go
+++ b/huggingface_cache_test.go
@@ -61,7 +61,7 @@ func isExpectedConcurrentCacheError(err error) bool {
 
 	// File not found (including wrapped errors and OS-specific messages)
 	if errors.Is(err, os.ErrNotExist) ||
-		strings.Contains(errMsg, "cache file not found") ||
+		errors.Is(err, ErrCacheNotFound) ||
 		strings.Contains(errMsg, "cannot find the file") ||
 		strings.Contains(errMsg, "no such file") {
 		return true


### PR DESCRIPTION
## Summary
Defines a sentinel error variable `ErrCacheNotFound` for cache-not-found conditions to improve API robustness and enable type-safe error checking.

## Changes
- Added `ErrCacheNotFound` sentinel error in `huggingface.go`
- Updated `loadFromCacheWithValidation` to return `ErrCacheNotFound` instead of string-based error
- Updated test helper `isExpectedConcurrentCacheError` to use `errors.Is(err, ErrCacheNotFound)` instead of string matching

## Benefits
- Type-safe error checking: `errors.Is(err, tokenizers.ErrCacheNotFound)`
- Clearer API contract for library consumers
- More robust than string matching
- Standard Go idiom (similar to `io.EOF`, `os.ErrNotExist`, etc.)

## Testing
- All existing cache tests pass
- Linting passes for both Go and Rust
- Backward compatible (error message unchanged)

Resolves #80