### PR TITLE
[TST] Handle Windows file locking in concurrent cache eviction test

### DIFF
--- a/huggingface_cache_test.go
+++ b/huggingface_cache_test.go
@@ -72,6 +72,11 @@ func isExpectedConcurrentCacheError(err error) bool {
 		return true
 	}
 
+	// Windows-specific file locking during concurrent access
+	if strings.Contains(errMsg, "being used by another process") {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## Summary
- Updated `isExpectedConcurrentCacheError` to handle Windows file locking errors
- Added check for "being used by another process" error message

## Details
Windows file locking is more aggressive than Unix-like systems. During concurrent cache eviction operations, when one goroutine is writing/recreating a file, other goroutines attempting to read get file locking errors with the message "being used by another process".

This is expected behavior during concurrent cache operations, so the helper function now recognizes this as an expected error rather than failing the test.

## Test Plan
- [x] Run `TestConcurrentCacheEviction` multiple times to verify it passes
- [x] Verify linting passes
- [ ] Confirm test passes on Windows CI

Closes #84