### PR TITLE
[PERF] Improve resource management in BenchmarkFromHuggingFace

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -186,6 +186,8 @@ func BenchmarkFromFile(b *testing.B) {
 }
 
 func BenchmarkFromHuggingFace(b *testing.B) {
+	b.ReportAllocs()
+
 	originalCache := os.Getenv("HF_HUB_CACHE")
 	tmpDir := b.TempDir()
 	_ = os.Setenv("HF_HUB_CACHE", tmpDir)
@@ -206,7 +208,6 @@ func BenchmarkFromHuggingFace(b *testing.B) {
 	_ = tokenizer.Close()
 
 	b.Run("CreationOnly", func(b *testing.B) {
-		b.ResetTimer()
 		for b.Loop() {
 			tokenizer, err := FromHuggingFace(modelID)
 			if err != nil {
@@ -219,7 +220,6 @@ func BenchmarkFromHuggingFace(b *testing.B) {
 	})
 
 	b.Run("FullLifecycle", func(b *testing.B) {
-		b.ResetTimer()
 		for b.Loop() {
 			tokenizer, err := FromHuggingFace(modelID)
 			if err != nil {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -205,14 +205,29 @@ func BenchmarkFromHuggingFace(b *testing.B) {
 	}
 	_ = tokenizer.Close()
 
-	b.ResetTimer()
-	for b.Loop() {
-		tokenizer, err := FromHuggingFace(modelID)
-		if err != nil {
-			b.Fatalf("Failed to load tokenizer: %v", err)
+	b.Run("CreationOnly", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			tokenizer, err := FromHuggingFace(modelID)
+			if err != nil {
+				b.Fatalf("Failed to load tokenizer: %v", err)
+			}
+			b.StopTimer()
+			_ = tokenizer.Close()
+			b.StartTimer()
 		}
-		_ = tokenizer.Close()
-	}
+	})
+
+	b.Run("FullLifecycle", func(b *testing.B) {
+		b.ResetTimer()
+		for b.Loop() {
+			tokenizer, err := FromHuggingFace(modelID)
+			if err != nil {
+				b.Fatalf("Failed to load tokenizer: %v", err)
+			}
+			_ = tokenizer.Close()
+		}
+	})
 }
 
 func BenchmarkVocabSize(b *testing.B) {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -185,6 +185,9 @@ func BenchmarkFromFile(b *testing.B) {
 	}
 }
 
+// BenchmarkFromHuggingFace measures tokenizer creation performance from HuggingFace Hub.
+// CreationOnly: measures just the FromHuggingFace call excluding Close() overhead
+// FullLifecycle: measures complete lifecycle including Close()
 func BenchmarkFromHuggingFace(b *testing.B) {
 	b.ReportAllocs()
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -207,15 +207,20 @@ func BenchmarkFromHuggingFace(b *testing.B) {
 	}
 	_ = tokenizer.Close()
 
+	b.ResetTimer()
+
 	b.Run("CreationOnly", func(b *testing.B) {
+		tokenizers := make([]*Tokenizer, 0, b.N)
 		for b.Loop() {
 			tokenizer, err := FromHuggingFace(modelID)
 			if err != nil {
 				b.Fatalf("Failed to load tokenizer: %v", err)
 			}
-			b.StopTimer()
-			_ = tokenizer.Close()
-			b.StartTimer()
+			tokenizers = append(tokenizers, tokenizer)
+		}
+		b.StopTimer()
+		for _, tok := range tokenizers {
+			_ = tok.Close()
 		}
 	})
 


### PR DESCRIPTION
## Summary
Split `BenchmarkFromHuggingFace` into two sub-benchmarks for clearer performance analysis:
- **CreationOnly**: Measures tokenizer creation time excluding `Close()` overhead
- **FullLifecycle**: Measures complete lifecycle including `Close()` overhead

## Implementation Details
- Modified `BenchmarkFromHuggingFace` to use sub-benchmarks with `b.Run()`
- Added `b.ReportAllocs()` to track memory allocation patterns
- Added `b.ResetTimer()` after warmup to exclude warmup time from measurements
- CreationOnly collects tokenizers in a slice and closes them after `b.StopTimer()` to avoid per-iteration timer overhead
- FullLifecycle preserves original behavior measuring total time including cleanup

## Benchmark Results
With `benchtime=1s`:
```
BenchmarkFromHuggingFace/CreationOnly-16   	      64	  18470865 ns/op
BenchmarkFromHuggingFace/FullLifecycle-16  	      58	  19838025 ns/op
```

The `Close()` overhead is approximately **1.37ms per operation** (19.84ms - 18.47ms).

Closes #54