### PR TITLE
fix: remove duplicate containsSubstring function

### DIFF
--- a/huggingface_integration_test.go
+++ b/huggingface_integration_test.go
@@ -410,7 +410,3 @@ func isRateLimitError(err error) bool {
 	}
 	return containsSubstring(err.Error(), "rate limit")
 }
-
-func containsSubstring(s, substr string) bool {
-	return strings.Contains(s, substr)
-}


### PR DESCRIPTION
## Summary
- Removed duplicate `containsSubstring` declaration from `huggingface_integration_test.go`
- Function already exists in `huggingface_suite_test.go` with case-insensitive matching
- Fixes build failure in HuggingFace Integration Tests workflow

## Root Cause
After PR #92 merged to main, the HuggingFace Integration Tests job started failing with:
```
./huggingface_suite_test.go:778:6: containsSubstring redeclared in this block
./huggingface_integration_test.go:414:6: other declaration of containsSubstring
```

## Test Plan
- [x] Verified the code compiles without errors
- [x] Integration tests run successfully