### PR TITLE
[DOC] Add comprehensive release documentation and automation skill

### DIFF
--- a/.claude/skills/SKILL.md
+++ b/.claude/skills/SKILL.md
@@ -1,0 +1,233 @@
+---
+description: Automated release process for pure-tokenizers (Rust + Go dual release) with user confirmation
+---
+
+You are helping create a new release for the pure-tokenizers project. This project requires coordinated releases of both Rust library binaries and the Go module.
+
+## Your Task
+
+Execute the complete release process, handling all steps from version bump through final verification. The process is automated but requires explicit user confirmation before executing any git operations (commits, pushes, tags).
+
+## Release Process Steps
+
+### 1. Initial Setup and Validation
+
+First, use the TodoWrite tool to create a comprehensive task list for the entire release process:
+
+```
+- Validate prerequisites and git state
+- Get version number from user
+- Update Cargo.toml with new version
+- Get user confirmation for git operations
+- Commit and push version bump
+- Create and push Rust release tag
+- Monitor Rust release workflow
+- Verify Rust release artifacts
+- Create and push Go release tag
+- Monitor Go release workflow
+- Handle Go release failures if needed
+- Verify final releases
+```
+
+Then validate:
+- Check `git status` shows clean working directory
+- Check current branch is `main`
+- Verify `gh` CLI is available and authenticated
+
+If any validation fails, stop and inform the user what needs to be fixed.
+
+### 2. Version Selection
+
+Ask the user what version they want to release using AskUserQuestion. Provide options like:
+- Patch bump (bug fixes only)
+- Minor bump (new features, no breaking changes)
+- Major bump (breaking changes)
+- Custom version
+
+Also show them the current version from `Cargo.toml` and recent commits since last release to help them decide.
+
+### 3. Update Cargo.toml
+
+- Read `Cargo.toml`
+- Update the version field to the new version
+- Use the Edit tool to make the change
+- Show the user the diff/change that was made
+- Mark todo as completed
+
+### 4. Get User Confirmation for Git Operations
+
+**IMPORTANT: Before executing ANY git commands, you must get explicit user confirmation.**
+
+Show the user a summary of what will happen:
+```
+Ready to proceed with release vX.Y.Z:
+
+Changes to commit:
+- Cargo.toml: version updated to X.Y.Z
+
+Git operations that will be performed:
+1. git add Cargo.toml
+2. git commit -m "chore: bump version to X.Y.Z"
+3. git push
+4. git tag rust-vX.Y.Z
+5. git push origin rust-vX.Y.Z
+6. git tag vX.Y.Z
+7. git push origin vX.Y.Z
+
+This will trigger CI/CD workflows and create public releases.
+```
+
+Use AskUserQuestion to ask:
+- Question: "Do you want to proceed with these git operations?"
+- Options: "Yes, proceed with release" / "No, cancel"
+
+If user selects "No, cancel":
+- Stop the release process
+- Inform user that they can manually review changes and restart when ready
+
+If user selects "Yes, proceed with release":
+- Continue to the next step
+
+### 5. Commit and Push Version Bump
+
+Execute:
+```bash
+git add Cargo.toml && git commit -m "chore: bump version to X.Y.Z" && git push
+```
+
+Mark todo as completed.
+
+### 6. Create Rust Release
+
+Execute:
+```bash
+git tag rust-vX.Y.Z && git push origin rust-vX.Y.Z
+```
+
+Inform user: "Creating Rust release rust-vX.Y.Z..."
+Mark todo as completed.
+
+### 7. Monitor Rust Release Workflow
+
+- Use `gh run list --limit 5` to find the "Rust Release" workflow run
+- Extract the run ID
+- Use `gh run watch <RUN_ID>` to monitor (with timeout of 600000ms / 10 minutes)
+- Mark todo as completed when workflow succeeds
+
+If the workflow fails, stop and inform the user about the failure with logs.
+
+### 8. Verify Rust Release Artifacts
+
+Execute:
+```bash
+gh release view rust-vX.Y.Z
+```
+
+Verify that all 7 platform artifacts are present:
+- libtokenizers-aarch64-apple-darwin.tar.gz
+- libtokenizers-aarch64-unknown-linux-gnu.tar.gz
+- libtokenizers-aarch64-unknown-linux-musl.tar.gz
+- libtokenizers-x86_64-apple-darwin.tar.gz
+- libtokenizers-x86_64-pc-windows-msvc.tar.gz
+- libtokenizers-x86_64-unknown-linux-gnu.tar.gz
+- libtokenizers-x86_64-unknown-linux-musl.tar.gz
+
+If any are missing, stop and inform the user.
+Mark todo as completed.
+
+### 9. Create Go Release
+
+Execute:
+```bash
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+Inform user: "Creating Go release vX.Y.Z..."
+Mark todo as completed.
+
+### 10. Monitor Go Release Workflow
+
+- Use `gh run list --limit 5` to find the "Go Release" workflow run
+- Extract the run ID
+- Use `gh run watch <RUN_ID>` to monitor (with timeout of 600000ms / 10 minutes)
+
+**Important**: The Go release may fail if it started too quickly and couldn't download Rust artifacts yet.
+
+If the workflow fails:
+1. Check the failure reason using `gh run view <RUN_ID> --log-failed`
+2. If the error contains "undefined symbol" (indicating timing issue):
+   - Inform user: "Go release failed due to timing issue. Retrying automatically..."
+   - Execute: `gh run rerun <RUN_ID> --failed`
+   - Monitor the re-run with `gh run watch <RUN_ID>` again
+   - If it succeeds on retry, mark todo as completed
+3. If it fails for other reasons, stop and inform the user
+
+Mark todo as completed when workflow succeeds.
+
+### 11. Verify Final Releases
+
+Execute both:
+```bash
+gh release view rust-vX.Y.Z
+gh release view vX.Y.Z
+```
+
+Confirm:
+- Rust release has all 7 artifacts
+- Go release was created
+- Both releases are published (not draft)
+
+Mark todo as completed.
+
+### 12. Success Summary
+
+Provide a clear summary:
+
+```
+✓ Release vX.Y.Z completed successfully!
+
+Rust Release: https://github.com/amikos-tech/pure-tokenizers/releases/tag/rust-vX.Y.Z
+Go Release: https://github.com/amikos-tech/pure-tokenizers/releases/tag/vX.Y.Z
+
+To install:
+go get github.com/amikos-tech/pure-tokenizers@vX.Y.Z
+
+All 7 platform binaries are available:
+- Linux (x86_64 + aarch64, GNU + MUSL)
+- macOS (x86_64 + Apple Silicon)
+- Windows (x86_64)
+```
+
+## Important Notes
+
+- **Always use TodoWrite** to track progress through all steps
+- **Mark todos completed** immediately after finishing each step
+- **Handle timing issues** - Go release may need retry if it starts too quickly
+- **Stop on errors** - Don't proceed if validation or workflows fail
+- **Be informative** - Tell the user what's happening at each step
+- **Verify everything** - Check that artifacts exist before proceeding
+
+## Error Handling
+
+Common issues and solutions:
+
+1. **"undefined symbol" in Go tests**: Timing issue, automatically retry the workflow
+2. **Missing artifacts**: Stop and report - likely a build failure
+3. **Workflow timeout**: Report to user with run ID so they can investigate
+4. **Git not clean**: Stop immediately and tell user to commit or stash changes
+5. **Not on main branch**: Stop and tell user to switch to main
+
+## Example Flow
+
+1. User invokes skill with `/release` or by asking to create a release
+2. Skill creates comprehensive todo list
+3. Skill validates prerequisites (git state, branch, tools)
+4. Skill asks user for version number
+5. Skill updates Cargo.toml and shows the change
+6. **Skill asks for explicit confirmation before any git operations**
+7. If confirmed, skill executes all git operations (commit, push, tags)
+8. Skill monitors workflows, updating todos as it progresses
+9. If Go release fails due to timing, skill automatically retries
+10. Skill provides final success summary with URLs
+
+The process is automated but safe - the user must explicitly confirm before any commits or pushes are made.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "cbindgen",
  "criterion",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,277 @@
+# Release Guide
+
+This guide provides step-by-step instructions for creating releases of the pure-tokenizers project.
+
+## Overview
+
+The project uses **separate release cycles** for Rust and Go components:
+- **Rust releases** (`rust-vX.Y.Z`): Platform-specific library binaries
+- **Go releases** (`vX.Y.Z`): Go module with public API
+
+Both must be released together for feature additions, with Rust released first.
+
+## Prerequisites
+
+- Git access with push permissions
+- GitHub CLI (`gh`) installed and authenticated
+- Understanding of [semantic versioning](https://semver.org/)
+- Clean working directory (`git status` shows no uncommitted changes)
+
+## Release Process
+
+### Step 1: Update Version in Cargo.toml
+
+Update the version number in `Cargo.toml`:
+
+```toml
+[package]
+name = "tokenizers"
+version = "0.1.2"  # Update this
+edition = "2021"
+```
+
+**Version Selection Guide:**
+- **Patch** (0.1.X): Bug fixes, no new features, no breaking changes
+- **Minor** (0.X.0): New features, no breaking changes
+- **Major** (X.0.0): Breaking changes to public API or FFI
+
+### Step 2: Commit and Push Version Bump
+
+```bash
+# Add the change
+git add Cargo.toml
+
+# Commit with conventional commit message
+git commit -m "chore: bump version to 0.1.2"
+
+# Push to main
+git push
+```
+
+### Step 3: Create Rust Release
+
+```bash
+# Create and push Rust release tag
+git tag rust-v0.1.2
+git push origin rust-v0.1.2
+```
+
+This triggers the `rust-release.yml` workflow which:
+- Builds library binaries for all supported platforms
+- Creates release with artifacts
+- Takes approximately 3-5 minutes
+
+**Monitor the build:**
+```bash
+# Watch the workflow
+gh run list --limit 5
+
+# Get the run ID for "Rust Release" and watch it
+gh run watch <RUN_ID>
+```
+
+### Step 4: Wait for Rust Release to Complete
+
+**Critical:** Do not proceed until the Rust release workflow completes successfully.
+
+**Verify Rust release:**
+```bash
+gh release view rust-v0.1.2
+```
+
+You should see 7 platform-specific assets:
+- `libtokenizers-aarch64-apple-darwin.tar.gz`
+- `libtokenizers-aarch64-unknown-linux-gnu.tar.gz`
+- `libtokenizers-aarch64-unknown-linux-musl.tar.gz`
+- `libtokenizers-x86_64-apple-darwin.tar.gz`
+- `libtokenizers-x86_64-pc-windows-msvc.tar.gz`
+- `libtokenizers-x86_64-unknown-linux-gnu.tar.gz`
+- `libtokenizers-x86_64-unknown-linux-musl.tar.gz`
+
+### Step 5: Create Go Release
+
+```bash
+# Create and push Go release tag
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+This triggers the `go-release.yml` workflow which:
+- Downloads the Rust v0.1.2 artifacts
+- Runs tests on multiple platforms
+- Creates the Go module release
+- Takes approximately 2-3 minutes
+
+**Monitor the build:**
+```bash
+gh run watch <GO_RELEASE_RUN_ID>
+```
+
+### Step 6: Verify Releases
+
+**Check Go release:**
+```bash
+gh release view v0.1.2
+```
+
+**Test the release:**
+```bash
+# In a test project
+go get github.com/amikos-tech/pure-tokenizers@v0.1.2
+```
+
+## Troubleshooting
+
+### Go Release Fails with "undefined symbol" Error
+
+**Symptom:** Go release tests fail with errors like:
+```
+undefined symbol: encode_batch_pairs
+```
+
+**Cause:** The Go release workflow started before the Rust release finished, so it fell back to building the Rust library locally from the wrong commit.
+
+**Solution:** Re-run the failed workflow:
+```bash
+# Find the failed run ID
+gh run list --workflow="Go Release" --limit 5
+
+# Re-run failed jobs
+gh run rerun <RUN_ID> --failed
+```
+
+The re-run will now download the correct Rust artifacts and should succeed.
+
+### Checking Workflow Status
+
+```bash
+# List recent runs
+gh run list --limit 10
+
+# View specific run details
+gh run view <RUN_ID>
+
+# View failed logs
+gh run view <RUN_ID> --log-failed
+
+# Watch a running workflow
+gh run watch <RUN_ID>
+```
+
+### Release Already Exists
+
+If you need to recreate a release:
+
+```bash
+# Delete the release and tag
+gh release delete v0.1.2 --yes
+git tag -d v0.1.2
+git push origin :refs/tags/v0.1.2
+
+# Recreate following the normal process
+```
+
+### Wrong Version Tagged
+
+If you tagged the wrong commit:
+
+```bash
+# Delete the remote tag
+git push origin :refs/tags/v0.1.2
+
+# Delete local tag
+git tag -d v0.1.2
+
+# Tag the correct commit
+git checkout <correct-commit-sha>
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+## Quick Reference
+
+### Complete Release Commands
+
+```bash
+# 1. Update version
+vim Cargo.toml  # Change version to X.Y.Z
+
+# 2. Commit and push
+git add Cargo.toml
+git commit -m "chore: bump version to X.Y.Z"
+git push
+
+# 3. Create Rust release
+git tag rust-vX.Y.Z
+git push origin rust-vX.Y.Z
+
+# 4. Wait and verify Rust release
+gh run watch <RUST_RUN_ID>
+gh release view rust-vX.Y.Z
+
+# 5. Create Go release
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+# 6. Verify Go release
+gh run watch <GO_RUN_ID>
+gh release view vX.Y.Z
+```
+
+### Monitoring Commands
+
+```bash
+# List recent workflow runs
+gh run list --limit 5
+
+# Watch specific run
+gh run watch <RUN_ID>
+
+# View release details
+gh release view <TAG>
+
+# List all releases
+gh release list
+```
+
+## Supported Platforms
+
+Each Rust release includes binaries for:
+
+| Platform | Architecture | File Extension |
+|----------|-------------|----------------|
+| Linux (GNU) | x86_64 | `.so` |
+| Linux (GNU) | aarch64 | `.so` |
+| Linux (MUSL) | x86_64 | `.so` |
+| Linux (MUSL) | aarch64 | `.so` |
+| macOS | x86_64 | `.dylib` |
+| macOS | Apple Silicon | `.dylib` |
+| Windows | x86_64 | `.dll` |
+
+## Release Checklist
+
+- [ ] Version updated in `Cargo.toml`
+- [ ] Version bump committed with conventional commit message
+- [ ] Changes pushed to main
+- [ ] Rust release tag created and pushed
+- [ ] Rust release workflow completed successfully
+- [ ] All 7 platform artifacts present in Rust release
+- [ ] Go release tag created and pushed
+- [ ] Go release workflow completed successfully
+- [ ] Both releases verified with `gh release view`
+- [ ] Test installation: `go get github.com/amikos-tech/pure-tokenizers@vX.Y.Z`
+
+## Common Mistakes to Avoid
+
+1. **Creating Go release before Rust completes** - Always wait for Rust release to finish
+2. **Mismatched versions** - Cargo.toml version must match the tag versions (without the `rust-` prefix)
+3. **Skipping version bump commit** - Always commit version changes before tagging
+4. **Not verifying artifacts** - Always check that all 7 platform binaries are present
+5. **Using wrong branch** - Always release from `main` branch
+
+## Additional Resources
+
+- [CI/CD Documentation](CI-CD.md)
+- [Deployment Guide](DEPLOYMENT.md)
+- [Semantic Versioning](https://semver.org/)
+- [Conventional Commits](https://www.conventionalcommits.org/)


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and tooling for the release process, capturing the learnings from creating v0.1.2.

## Changes

### 📚 Documentation
- **`docs/RELEASE.md`**: Complete step-by-step release guide
  - Prerequisites and version selection guidance
  - Detailed 6-step process with exact commands
  - Troubleshooting section for common issues
  - Quick reference and release checklist
  - Platform support matrix

### 🤖 Automation
- **`.claude/skills/SKILL.md`**: Automated release skill for Claude Code
  - Validates prerequisites automatically
  - Interactive version selection
  - Updates Cargo.toml
  - **Requires user confirmation before git operations**
  - Monitors workflows and handles failures
  - Auto-retries Go release if timing issue occurs
  - Provides final verification and summary

## Key Features

### Release Documentation
- Clear explanation of dual release cycle (Rust + Go)
- Emphasis on correct sequencing (Rust must complete before Go)
- Troubleshooting for the "undefined symbol" timing issue
- Common mistakes to avoid
- Monitoring commands using `gh` CLI

### Automation Skill
- Semi-automated: handles complexity while requiring user confirmation
- Shows exactly what will be committed/pushed before executing
- Tracks progress with TodoWrite
- Intelligent retry logic for timing-related failures
- Comprehensive error handling

## Testing

- [x] Skill created following Claude Code specs (SKILL.md as entrypoint)
- [x] Documentation includes all steps from successful v0.1.2 release
- [x] User confirmation step prevents accidental pushes

## Usage

After merging, the skill can be invoked with:
```
/release
```

Or naturally:
```
"Create a new release"
"I want to release version 0.1.3"
```

## Related

Based on the successful release of v0.1.2 which included:
- feat: add batch pair encoding support for reranker use cases (#96)

**Full Changelog**: https://github.com/amikos-tech/pure-tokenizers/compare/v0.1.1...v0.1.2