### PR TITLE
ci: publish signed Rust releases to R2

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -8,8 +8,8 @@ on:
 
 permissions:
   actions: write
-  packages: write
   contents: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -111,7 +111,7 @@ jobs:
 
         # Create the final archive with all contents
         cd release-staging
-        tar -czf ../${{ matrix.archive-name }} *
+        tar -czf ../${{ matrix.archive-name }} ./*
         cd ..
 
         # Display archive contents for verification
@@ -164,9 +164,14 @@ jobs:
         path: ${{ matrix.archive-name }}
 
   release:
-    name: Create Release
+    name: Sign & Publish Release
     runs-on: ubuntu-latest
     needs: build
+    env:
+      BUCKET: releases
+      PROJECT: ${{ github.event.repository.name }}
+      VERSION: ${{ github.ref_name }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
 
     steps:
       - name: Checkout code
@@ -178,23 +183,174 @@ jobs:
           path: artifacts
 
       - name: Prepare release assets
+        shell: bash
         run: |
-          mkdir -p release-assets
-          # Each artifact is already a complete tar.gz archive
-          find artifacts -name "*.tar.gz" -exec cp {} release-assets/ \;
+          set -euo pipefail
+          mkdir -p dist
+          find artifacts -name "*.tar.gz" -exec cp {} dist/ \;
 
-          # Verify archives
-          echo "Release assets:"
-          ls -la release-assets/
+          shopt -s nullglob
+          archives=(dist/*.tar.gz)
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "No release archives found"
+            exit 1
+          fi
 
-          # Show contents of one archive as example
-          echo "Example archive contents:"
-          tar -tzf release-assets/libtokenizers-x86_64-unknown-linux-gnu.tar.gz || true
+          echo "Release archives:"
+          ls -la dist/
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          shopt -s nullglob
+          archives=( *.tar.gz )
+          if [ "${#archives[@]}" -eq 0 ]; then
+            echo "No release archives found for checksum generation"
+            exit 1
+          fi
+          sha256sum -- "${archives[@]}" > SHA256SUMS
+          while read -r checksum file; do
+            printf "%s  %s\n" "${checksum}" "${file}" > "${file}.sha256"
+          done < SHA256SUMS
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign artifacts (keyless)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          ISSUER="https://token.actions.githubusercontent.com"
+          shopt -s nullglob
+          archives=( *.tar.gz )
+          for f in "${archives[@]}"; do
+            cosign sign-blob --yes \
+              --oidc-issuer "${ISSUER}" \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "${f}"
+          done
+
+          cosign sign-blob --yes \
+            --oidc-issuer "${ISSUER}" \
+            --output-signature "SHA256SUMS.sig" \
+            --output-certificate "SHA256SUMS.pem" \
+            "SHA256SUMS"
+
+      - name: Verify signatures
+        shell: bash
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cd dist
+          IDENTITY="https://github.com/${REPO}/.github/workflows/rust-release.yml@refs/tags/${TAG}"
+          ISSUER="https://token.actions.githubusercontent.com"
+          shopt -s nullglob
+          archives=( *.tar.gz )
+
+          sha256sum -c SHA256SUMS
+
+          for f in "${archives[@]}"; do
+            cosign verify-blob \
+              --signature "${f}.sig" \
+              --certificate "${f}.pem" \
+              --certificate-identity "${IDENTITY}" \
+              --certificate-oidc-issuer "${ISSUER}" \
+              "${f}"
+            echo "Verified ${f}"
+          done
+
+          cosign verify-blob \
+            --signature "SHA256SUMS.sig" \
+            --certificate "SHA256SUMS.pem" \
+            --certificate-identity "${IDENTITY}" \
+            --certificate-oidc-issuer "${ISSUER}" \
+            "SHA256SUMS"
+          echo "Verified SHA256SUMS"
+
+      - name: Validate R2 settings
+        shell: bash
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          for var in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT; do
+            if [ -z "${!var}" ]; then
+              echo "Missing required secret: ${var}"
+              exit 1
+            fi
+          done
+
+      - name: Check release immutability in R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          PREFIX="s3://${BUCKET}/${PROJECT}/${VERSION}/"
+          if aws s3 ls "${PREFIX}" --endpoint-url "${R2_ENDPOINT}" | grep -q .; then
+            echo "Release prefix already exists: ${PREFIX}"
+            echo "Refusing to overwrite immutable release artifacts."
+            exit 1
+          fi
+
+      - name: Upload artifacts to R2
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          aws s3 cp dist/ "s3://${BUCKET}/${PROJECT}/${VERSION}/" \
+            --recursive \
+            --endpoint-url "${R2_ENDPOINT}"
+
+          cat > /tmp/latest.json <<EOF
+          {
+            "version": "${VERSION}",
+            "date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "checksums_url": "${PROJECT}/${VERSION}/SHA256SUMS"
+          }
+          EOF
+
+          aws s3 cp /tmp/latest.json "s3://${BUCKET}/${PROJECT}/latest.json" \
+            --endpoint-url "${R2_ENDPOINT}" \
+            --content-type "application/json" \
+            --cache-control "public, max-age=60"
+
+      - name: Purge latest.json from CDN cache
+        if: vars.CF_ZONE_ID != '' && env.CLOUDFLARE_API_TOKEN != ''
+        shell: bash
+        env:
+          CF_ZONE_ID: ${{ vars.CF_ZONE_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          RELEASES_DOMAIN: ${{ vars.RELEASES_DOMAIN || 'releases.amikos.tech' }}
+        run: |
+          set -euo pipefail
+          curl -sf -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data "{\"files\":[\"https://${RELEASES_DOMAIN}/${PROJECT}/latest.json\"]}"
+          echo "CDN cache purged for ${PROJECT}/latest.json"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: release-assets/*
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/SHA256SUMS
+            dist/*.sig
+            dist/*.pem
           name: Rust Library ${{ github.ref_name }}
           body: |
             ## Rust Tokenizers Library Release
@@ -216,6 +372,10 @@ jobs:
             ### Usage with Go bindings
             The Go bindings will automatically download these libraries when needed.
             You can also set `TOKENIZERS_LIB_PATH` environment variable to use a specific library.
+
+            ### R2 Release Endpoint
+            Release assets are also published to:
+            `https://${{ vars.RELEASES_DOMAIN || 'releases.amikos.tech' }}/${{ github.event.repository.name }}/${{ github.ref_name }}/`
           fail_on_unmatched_files: true
           generate_release_notes: true
         env:


### PR DESCRIPTION
## Summary\n- add keyless cosign signing and verification for Rust release artifacts\n- publish release assets to R2 under  and update \n- keep GitHub release uploads for compatibility and add optional Cloudflare cache purge\n\n## Validation\n- actionlint .github/workflows/rust-release.yml\n- ruby YAML parse check