### PR TITLE
Fix tokenizer lifecycle close races

### DIFF
--- a/tokenizer_lifecycle_test.go
+++ b/tokenizer_lifecycle_test.go
@@ -82,7 +82,7 @@ func TestCloseWaitsForActiveOperations(t *testing.T) {
 	select {
 	case err := <-closeDone:
 		t.Fatalf("Close returned before active operations finished: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	tok.lifecycleMu.RUnlock()
@@ -138,8 +138,12 @@ func TestConcurrentMixedOperationsAndClose(t *testing.T) {
 	baseline, err := tok.Encode("Mixed lifecycle test text")
 	require.NoError(t, err)
 	require.NotEmpty(t, baseline.IDs)
+	pairBaseline, err := tok.EncodePairs([]string{"query"}, []string{"document"})
+	require.NoError(t, err)
+	require.Len(t, pairBaseline, 1)
+	require.NotEmpty(t, pairBaseline[0].IDs)
 
-	const goroutines = 9
+	const goroutines = 12
 	const iterationsPerGoroutine = 150
 
 	start := make(chan struct{})
@@ -153,7 +157,7 @@ func TestConcurrentMixedOperationsAndClose(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for j := 0; j < iterationsPerGoroutine; j++ {
-				switch workerID % 3 {
+				switch workerID % 4 {
 				case 0:
 					result, opErr := tok.Encode("Mixed lifecycle test text")
 					if opErr == nil && len(result.IDs) == 0 {
@@ -174,10 +178,20 @@ func TestConcurrentMixedOperationsAndClose(t *testing.T) {
 						errs <- opErr
 						return
 					}
-				default:
+				case 2:
 					size, opErr := tok.VocabSize()
 					if opErr == nil && size == 0 {
 						errs <- stderrors.New("mixed vocab size returned zero")
+						return
+					}
+					if opErr != nil && !stderrors.Is(opErr, ErrTokenizerClosed) {
+						errs <- opErr
+						return
+					}
+				default:
+					results, opErr := tok.EncodePairs([]string{"query"}, []string{"document"})
+					if opErr == nil && (len(results) != 1 || len(results[0].IDs) == 0) {
+						errs <- stderrors.New("mixed encode pairs returned empty ids")
 						return
 					}
 					if opErr != nil && !stderrors.Is(opErr, ErrTokenizerClosed) {

--- a/tokenizer_lifecycle_test.go
+++ b/tokenizer_lifecycle_test.go
@@ -1,0 +1,107 @@
+package tokenizers
+
+import (
+	stderrors "errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newLifecycleTestTokenizer(t *testing.T) *Tokenizer {
+	t.Helper()
+
+	libpath := checkLibraryExists(t)
+	tok, err := FromFile("./tokenizer.json", WithLibraryPath(libpath))
+	require.NoError(t, err, "Failed to load tokenizer from file")
+	return tok
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	require.NoError(t, tok.Close())
+	require.NoError(t, tok.Close())
+}
+
+func TestTokenizerMethodsReturnErrTokenizerClosed(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	encoding, err := tok.Encode("Hello, world!")
+	require.NoError(t, err)
+
+	require.NoError(t, tok.Close())
+
+	_, err = tok.Encode("Hello again")
+	require.ErrorIs(t, err, ErrTokenizerClosed)
+
+	_, err = tok.EncodePairs([]string{"query"}, []string{"document"})
+	require.ErrorIs(t, err, ErrTokenizerClosed)
+
+	_, err = tok.Decode(encoding.IDs, false)
+	require.ErrorIs(t, err, ErrTokenizerClosed)
+
+	_, err = tok.VocabSize()
+	require.ErrorIs(t, err, ErrTokenizerClosed)
+
+	require.Equal(t, "unknown", tok.GetLibraryVersion())
+}
+
+func TestCloseWaitsForActiveOperations(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	tok.lifecycleMu.RLock()
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- tok.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before active operations finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	tok.lifecycleMu.RUnlock()
+	require.NoError(t, <-closeDone)
+
+	_, err := tok.Encode("Hello after close")
+	require.ErrorIs(t, err, ErrTokenizerClosed)
+}
+
+func TestConcurrentEncodeAndClose(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	const goroutines = 8
+	const iterationsPerGoroutine = 200
+
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterationsPerGoroutine; j++ {
+				_, err := tok.Encode("Concurrent lifecycle test text")
+				if err != nil && !stderrors.Is(err, ErrTokenizerClosed) {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, tok.Close())
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/tokenizer_lifecycle_test.go
+++ b/tokenizer_lifecycle_test.go
@@ -25,6 +25,28 @@ func TestCloseIsIdempotent(t *testing.T) {
 	require.NoError(t, tok.Close())
 }
 
+func TestConcurrentCloseIsIdempotent(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	const goroutines = 8
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			errs <- tok.Close()
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
 func TestTokenizerMethodsReturnErrTokenizerClosed(t *testing.T) {
 	tok := newLifecycleTestTokenizer(t)
 
@@ -86,10 +108,82 @@ func TestConcurrentEncodeAndClose(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for j := 0; j < iterationsPerGoroutine; j++ {
-				_, err := tok.Encode("Concurrent lifecycle test text")
+				result, err := tok.Encode("Concurrent lifecycle test text")
 				if err != nil && !stderrors.Is(err, ErrTokenizerClosed) {
 					errs <- err
 					return
+				}
+				if err == nil && len(result.IDs) == 0 {
+					errs <- stderrors.New("encode returned empty ids")
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, tok.Close())
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestConcurrentMixedOperationsAndClose(t *testing.T) {
+	tok := newLifecycleTestTokenizer(t)
+
+	baseline, err := tok.Encode("Mixed lifecycle test text")
+	require.NoError(t, err)
+	require.NotEmpty(t, baseline.IDs)
+
+	const goroutines = 9
+	const iterationsPerGoroutine = 150
+
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		workerID := i
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterationsPerGoroutine; j++ {
+				switch workerID % 3 {
+				case 0:
+					result, opErr := tok.Encode("Mixed lifecycle test text")
+					if opErr == nil && len(result.IDs) == 0 {
+						errs <- stderrors.New("mixed encode returned empty ids")
+						return
+					}
+					if opErr != nil && !stderrors.Is(opErr, ErrTokenizerClosed) {
+						errs <- opErr
+						return
+					}
+				case 1:
+					decoded, opErr := tok.Decode(baseline.IDs, false)
+					if opErr == nil && decoded == "" {
+						errs <- stderrors.New("mixed decode returned empty string")
+						return
+					}
+					if opErr != nil && !stderrors.Is(opErr, ErrTokenizerClosed) {
+						errs <- opErr
+						return
+					}
+				default:
+					size, opErr := tok.VocabSize()
+					if opErr == nil && size == 0 {
+						errs <- stderrors.New("mixed vocab size returned zero")
+						return
+					}
+					if opErr != nil && !stderrors.Is(opErr, ErrTokenizerClosed) {
+						errs <- opErr
+						return
+					}
 				}
 			}
 		}()

--- a/tokenizers.go
+++ b/tokenizers.go
@@ -437,7 +437,7 @@ func (t *Tokenizer) Close() (err error) {
 	if tokenizerh != nil && freeTokenizer != nil {
 		freeTokenizer(tokenizerh)
 	}
-	return nil
+	return
 }
 
 func (t *Tokenizer) Encode(message string, opts ...EncodeOption) (*EncodeResult, error) {

--- a/tokenizers.go
+++ b/tokenizers.go
@@ -3,6 +3,7 @@ package tokenizers
 import (
 	"math"
 	"os"
+	"sync"
 	"unsafe"
 
 	"github.com/Masterminds/semver/v3"
@@ -27,6 +28,9 @@ const (
 	ErrInvalidIDs              = -13
 	ErrInvalidOptions          = -14
 )
+
+// ErrTokenizerClosed is returned when an operation is attempted on a closed tokenizer.
+var ErrTokenizerClosed = errors.New("tokenizer is closed")
 
 // AbiCompatibilityConstraint defines the required version range for ABI compatibility.
 // The library version from Cargo.toml is used as the ABI version.
@@ -218,6 +222,8 @@ func WithPadding(enabled bool, strategy PaddingStrategy) TokenizerOption {
 }
 
 type Tokenizer struct {
+	lifecycleMu         sync.RWMutex
+	closed              bool
 	LibraryPath         string // Path to the shared library
 	libh                uintptr
 	tokenizerh          unsafe.Pointer // Pointer to the tokenizer instance
@@ -384,19 +390,57 @@ To resolve this issue:
 	return nil
 }
 
-func (t *Tokenizer) Close() error {
-	if t.tokenizerh != nil {
-		t.freeTokenizer(t.tokenizerh)
-		t.tokenizerh = nil
+func (t *Tokenizer) beginOperation() error {
+	t.lifecycleMu.RLock()
+	if t.closed {
+		t.lifecycleMu.RUnlock()
+		return ErrTokenizerClosed
 	}
-	err := closeLibrary(t.libh)
-	if err != nil {
+	return nil
+}
+
+func (t *Tokenizer) Close() error {
+	t.lifecycleMu.Lock()
+	defer t.lifecycleMu.Unlock()
+
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+
+	if t.tokenizerh != nil && t.freeTokenizer != nil {
+		t.freeTokenizer(t.tokenizerh)
+	}
+	t.tokenizerh = nil
+
+	libh := t.libh
+	t.libh = 0
+	t.fromFile = nil
+	t.fromBytes = nil
+	t.encode = nil
+	t.encodeBatchPairs = nil
+	t.freeTokenizer = nil
+	t.freeBuffer = nil
+	t.freeString = nil
+	t.decode = nil
+	t.vocabSize = nil
+	t.getVersion = nil
+
+	if libh == 0 {
+		return nil
+	}
+	if err := closeLibrary(libh); err != nil {
 		return errors.Errorf("failed to close shared library: %s", err.Error())
 	}
 	return nil
 }
 
 func (t *Tokenizer) Encode(message string, opts ...EncodeOption) (*EncodeResult, error) {
+	if err := t.beginOperation(); err != nil {
+		return nil, err
+	}
+	defer t.lifecycleMu.RUnlock()
+
 	if t.encode == nil || t.tokenizerh == nil {
 		return nil, errors.New("encode function is not initialized or tokenizer is not loaded")
 	}
@@ -454,6 +498,11 @@ func (t *Tokenizer) Encode(message string, opts ...EncodeOption) (*EncodeResult,
 // EncodePairs encodes multiple sequence pairs in parallel.
 // This is useful for reranking tasks where you need to encode query-document pairs.
 func (t *Tokenizer) EncodePairs(sequences []string, pairs []string, opts ...EncodeOption) ([]*EncodeResult, error) {
+	if err := t.beginOperation(); err != nil {
+		return nil, err
+	}
+	defer t.lifecycleMu.RUnlock()
+
 	if t.encodeBatchPairs == nil || t.tokenizerh == nil {
 		return nil, errors.New("encode_batch_pairs function is not initialized or tokenizer is not loaded")
 	}
@@ -566,6 +615,11 @@ func (t *Tokenizer) EncodePair(sequence string, pair string, opts ...EncodeOptio
 }
 
 func (t *Tokenizer) Decode(ids []uint32, skipSpecialTokens bool) (string, error) {
+	if err := t.beginOperation(); err != nil {
+		return "", err
+	}
+	defer t.lifecycleMu.RUnlock()
+
 	if t.decode == nil || t.tokenizerh == nil {
 		return "", errors.New("decode function is not initialized or tokenizer is not loaded")
 	}
@@ -618,6 +672,11 @@ func goStringFromPtr(ptr unsafe.Pointer) string {
 	return string(unsafe.Slice(p, n)) // #nosec G103 -- Converts validated null-terminated FFI buffer into a Go string.
 }
 func (t *Tokenizer) VocabSize() (uint32, error) {
+	if err := t.beginOperation(); err != nil {
+		return 0, err
+	}
+	defer t.lifecycleMu.RUnlock()
+
 	if t.vocabSize == nil || t.tokenizerh == nil {
 		return 0, errors.New("vocabSize function is not initialized or tokenizer is not loaded")
 	}
@@ -670,6 +729,11 @@ func getErrorForCode(errCode int32) error {
 
 // GetLibraryVersion returns the version of the tokenizer library
 func (t *Tokenizer) GetLibraryVersion() string {
+	if err := t.beginOperation(); err != nil {
+		return "unknown"
+	}
+	defer t.lifecycleMu.RUnlock()
+
 	if t.getVersion == nil {
 		return "unknown"
 	}

--- a/tokenizers.go
+++ b/tokenizers.go
@@ -390,30 +390,28 @@ To resolve this issue:
 	return nil
 }
 
-func (t *Tokenizer) beginOperation() error {
+func (t *Tokenizer) beginOperation() (func(), error) {
 	t.lifecycleMu.RLock()
 	if t.closed {
 		t.lifecycleMu.RUnlock()
-		return ErrTokenizerClosed
+		return nil, ErrTokenizerClosed
 	}
-	return nil
+	return t.lifecycleMu.RUnlock, nil
 }
 
-func (t *Tokenizer) Close() error {
+func (t *Tokenizer) Close() (err error) {
 	t.lifecycleMu.Lock()
-	defer t.lifecycleMu.Unlock()
-
 	if t.closed {
+		t.lifecycleMu.Unlock()
 		return nil
 	}
 	t.closed = true
 
-	if t.tokenizerh != nil && t.freeTokenizer != nil {
-		t.freeTokenizer(t.tokenizerh)
-	}
-	t.tokenizerh = nil
-
+	tokenizerh := t.tokenizerh
+	freeTokenizer := t.freeTokenizer
 	libh := t.libh
+
+	t.tokenizerh = nil
 	t.libh = 0
 	t.fromFile = nil
 	t.fromBytes = nil
@@ -426,20 +424,28 @@ func (t *Tokenizer) Close() error {
 	t.vocabSize = nil
 	t.getVersion = nil
 
-	if libh == 0 {
-		return nil
+	t.lifecycleMu.Unlock()
+
+	if libh != 0 {
+		defer func() {
+			if closeErr := closeLibrary(libh); err == nil && closeErr != nil {
+				err = closeErr
+			}
+		}()
 	}
-	if err := closeLibrary(libh); err != nil {
-		return errors.Errorf("failed to close shared library: %s", err.Error())
+
+	if tokenizerh != nil && freeTokenizer != nil {
+		freeTokenizer(tokenizerh)
 	}
 	return nil
 }
 
 func (t *Tokenizer) Encode(message string, opts ...EncodeOption) (*EncodeResult, error) {
-	if err := t.beginOperation(); err != nil {
+	unlock, err := t.beginOperation()
+	if err != nil {
 		return nil, err
 	}
-	defer t.lifecycleMu.RUnlock()
+	defer unlock()
 
 	if t.encode == nil || t.tokenizerh == nil {
 		return nil, errors.New("encode function is not initialized or tokenizer is not loaded")
@@ -498,10 +504,11 @@ func (t *Tokenizer) Encode(message string, opts ...EncodeOption) (*EncodeResult,
 // EncodePairs encodes multiple sequence pairs in parallel.
 // This is useful for reranking tasks where you need to encode query-document pairs.
 func (t *Tokenizer) EncodePairs(sequences []string, pairs []string, opts ...EncodeOption) ([]*EncodeResult, error) {
-	if err := t.beginOperation(); err != nil {
+	unlock, err := t.beginOperation()
+	if err != nil {
 		return nil, err
 	}
-	defer t.lifecycleMu.RUnlock()
+	defer unlock()
 
 	if t.encodeBatchPairs == nil || t.tokenizerh == nil {
 		return nil, errors.New("encode_batch_pairs function is not initialized or tokenizer is not loaded")
@@ -553,6 +560,11 @@ func (t *Tokenizer) EncodePairs(sequences []string, pairs []string, opts ...Enco
 		lastError := getErrorForCode(rc)
 		return nil, errors.Wrap(lastError, "failed to encode pairs")
 	}
+	defer func() {
+		for i := range buffers {
+			t.freeBuffer(&buffers[i])
+		}
+	}()
 
 	// Convert buffers to results
 	results := make([]*EncodeResult, len(buffers))
@@ -596,9 +608,6 @@ func (t *Tokenizer) EncodePairs(sequences []string, pairs []string, opts ...Enco
 		}
 
 		results[i] = result
-
-		// Free the buffer
-		t.freeBuffer(buff)
 	}
 
 	return results, nil
@@ -615,10 +624,11 @@ func (t *Tokenizer) EncodePair(sequence string, pair string, opts ...EncodeOptio
 }
 
 func (t *Tokenizer) Decode(ids []uint32, skipSpecialTokens bool) (string, error) {
-	if err := t.beginOperation(); err != nil {
+	unlock, err := t.beginOperation()
+	if err != nil {
 		return "", err
 	}
-	defer t.lifecycleMu.RUnlock()
+	defer unlock()
 
 	if t.decode == nil || t.tokenizerh == nil {
 		return "", errors.New("decode function is not initialized or tokenizer is not loaded")
@@ -672,10 +682,11 @@ func goStringFromPtr(ptr unsafe.Pointer) string {
 	return string(unsafe.Slice(p, n)) // #nosec G103 -- Converts validated null-terminated FFI buffer into a Go string.
 }
 func (t *Tokenizer) VocabSize() (uint32, error) {
-	if err := t.beginOperation(); err != nil {
+	unlock, err := t.beginOperation()
+	if err != nil {
 		return 0, err
 	}
-	defer t.lifecycleMu.RUnlock()
+	defer unlock()
 
 	if t.vocabSize == nil || t.tokenizerh == nil {
 		return 0, errors.New("vocabSize function is not initialized or tokenizer is not loaded")
@@ -727,12 +738,14 @@ func getErrorForCode(errCode int32) error {
 	}
 }
 
-// GetLibraryVersion returns the version of the tokenizer library
+// GetLibraryVersion returns the version of the tokenizer library.
+// It returns "unknown" when the version callback is unavailable or the tokenizer is closed.
 func (t *Tokenizer) GetLibraryVersion() string {
-	if err := t.beginOperation(); err != nil {
+	unlock, err := t.beginOperation()
+	if err != nil {
 		return "unknown"
 	}
-	defer t.lifecycleMu.RUnlock()
+	defer unlock()
 
 	if t.getVersion == nil {
 		return "unknown"


### PR DESCRIPTION
## Summary
- guard Tokenizer lifecycle with an RWMutex and ErrTokenizerClosed so Close() cannot race in-flight operations
- fix EncodePairs buffer cleanup on all return paths and harden Close() teardown ordering
- add concurrent lifecycle coverage for Encode, EncodePairs, Decode, VocabSize, and concurrent double-close

## Testing
- go test ./... -count=1
- go test -race ./... -count=1

Closes #108
